### PR TITLE
Handle lines that have charge taxes set to false

### DIFF
--- a/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
@@ -13,7 +13,7 @@ import * as joseModule from "jose";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as taxJarRequest from "taxjar/dist/util/request";
 import { Request } from "taxjar/dist/util/types";
-import * as calculateTaxes from "../../../pages/api/webhooks/checkout-calculate-taxes";
+import toNextHandler from "../../../pages/api/webhooks/checkout-calculate-taxes";
 
 jest.mock("next/dist/compiled/raw-body/index.js", () => ({
   __esModule: true,
@@ -49,7 +49,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     const checkoutPayload = { ...dummyFetchTaxesPayload };
     req.body = [checkoutPayload];
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -78,7 +78,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     const checkoutPayload = { ...dummyFetchTaxesPayload };
     req.body = [checkoutPayload];
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -109,7 +109,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -147,7 +147,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -169,11 +169,9 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const checkoutPayload = { ...dummyCheckoutPayload };
@@ -188,7 +186,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
       toString: () => JSON.stringify([checkoutPayload]),
     });
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -218,11 +216,9 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
     const checkoutPayload = { ...dummyCheckoutPayload };
 
@@ -240,7 +236,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -271,11 +267,9 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
     const checkoutPayload = { ...dummyCheckoutPayload };
 
@@ -298,7 +292,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -329,11 +323,9 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
     const checkoutPayload = { ...dummyCheckoutPayload };
 
@@ -357,7 +349,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -389,11 +381,9 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
     const checkoutPayload = { ...dummyCheckoutPayload };
 
@@ -417,7 +407,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );

--- a/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
@@ -46,7 +46,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
       domain,
     });
 
-    const checkoutPayload = dummyFetchTaxesPayload;
+    const checkoutPayload = { ...dummyFetchTaxesPayload };
     req.body = [checkoutPayload];
 
     await calculateTaxes.default(
@@ -75,7 +75,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
       domain: testDomain,
     });
 
-    const checkoutPayload = dummyFetchTaxesPayload;
+    const checkoutPayload = { ...dummyFetchTaxesPayload };
     req.body = [checkoutPayload];
 
     await calculateTaxes.default(
@@ -105,8 +105,6 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
       signature,
     });
 
-    const checkoutPayload = dummyFetchTaxesPayload;
-
     // set body to undefined as the webhook handler expects that
     // the processed body doesn't exist.
     req.body = undefined;
@@ -130,7 +128,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
       .spyOn(taxJarRequest, "default")
       .mockImplementation((_) => ({ post: post } as unknown as Request));
 
-    const checkoutPayload = dummyCheckoutPayload;
+    const checkoutPayload = { ...dummyCheckoutPayload };
     // set mock on next built-in library that build the payload from stream.
     const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
     rawBodyModule.default.mockReturnValue({
@@ -178,7 +176,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
         )
       );
 
-    const checkoutPayload = dummyCheckoutPayload;
+    const checkoutPayload = { ...dummyCheckoutPayload };
 
     // set body to undefined as the webhook handler expects that
     // the processed body doesn't exist.
@@ -226,7 +224,7 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
             joseModule.ResolvedKey
         )
       );
-    const checkoutPayload = dummyCheckoutPayload;
+    const checkoutPayload = { ...dummyCheckoutPayload };
 
     checkoutPayload.discounts = [{ amount: "2" }, { amount: "1" }];
     const linePayload = checkoutPayload.lines[0];
@@ -257,6 +255,183 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     expect(data.lines[1].total_gross_amount).toBe("32.60");
     expect(data.lines[1].total_net_amount).toBe("26.50");
     expect(data.lines[1].tax_rate).toBe("0.23");
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockReturnValue(
+        Promise.resolve(
+          {} as unknown as joseModule.FlattenedVerifyResult &
+            joseModule.ResolvedKey
+        )
+      );
+    const checkoutPayload = { ...dummyCheckoutPayload };
+
+    const linePayload = checkoutPayload.lines[0];
+    const secondLinePayload = {
+      ...linePayload,
+      id: "Q2hlY2tvdXRMaW5lOjc=",
+      charge_taxes: false,
+    };
+
+    checkoutPayload.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify([checkoutPayload]),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await calculateTaxes.default(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("34.44");
+    expect(data.lines[0].total_net_amount).toBe("28.00");
+    expect(data.lines[0].tax_rate).toBe("0.23");
+
+    expect(data.lines[1].total_gross_amount).toBe("28.00");
+    expect(data.lines[1].total_net_amount).toBe("28.00");
+    expect(data.lines[1].tax_rate).toBe("0");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("with discounts and line that should not have calculated taxes", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockReturnValue(
+        Promise.resolve(
+          {} as unknown as joseModule.FlattenedVerifyResult &
+            joseModule.ResolvedKey
+        )
+      );
+    const checkoutPayload = { ...dummyCheckoutPayload };
+
+    checkoutPayload.discounts = [{ amount: "2" }, { amount: "1" }];
+    const linePayload = checkoutPayload.lines[0];
+    const secondLinePayload = {
+      ...linePayload,
+      id: "Q2hlY2tvdXRMaW5lOjc=",
+      charge_taxes: false,
+    };
+
+    checkoutPayload.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify([checkoutPayload]),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await calculateTaxes.default(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    // amounts already include propagated discount
+    expect(data.lines[0].total_gross_amount).toBe("32.60");
+    expect(data.lines[0].total_net_amount).toBe("26.50");
+    expect(data.lines[0].tax_rate).toBe("0.23");
+
+    expect(data.lines[1].total_gross_amount).toBe("26.50");
+    expect(data.lines[1].total_net_amount).toBe("26.50");
+    expect(data.lines[1].tax_rate).toBe("0");
+
+    expect(res.statusCode).toBe(200);
+
+    mockJose.mockRestore();
+  });
+
+  it("all lines with charge taxes set to false", async () => {
+    const { req, res } = mockRequest({
+      method: "POST",
+      event: "checkout_calculate_taxes",
+      domain: testDomain,
+      signature:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6..-Y1p0YWNAuX0kOPIhfjoNoyWAkvRl6iMxWQ",
+    });
+
+    const mockJose = jest
+      .spyOn(joseModule, "flattenedVerify")
+      .mockReturnValue(
+        Promise.resolve(
+          {} as unknown as joseModule.FlattenedVerifyResult &
+            joseModule.ResolvedKey
+        )
+      );
+    const checkoutPayload = { ...dummyCheckoutPayload };
+
+    const linePayload = checkoutPayload.lines[0];
+    linePayload.charge_taxes = false;
+    const secondLinePayload = {
+      ...linePayload,
+      id: "Q2hlY2tvdXRMaW5lOjc=",
+      charge_taxes: false,
+    };
+
+    checkoutPayload.lines = [linePayload, secondLinePayload];
+
+    // set mock on next built-in library that build the payload from stream.
+    const rawBodyModule = require("next/dist/compiled/raw-body/index.js");
+    rawBodyModule.default.mockReturnValue({
+      toString: () => JSON.stringify([checkoutPayload]),
+    });
+
+    // set body to undefined as the webhook handler expects that
+    // the processed body doesn't exist.
+    req.body = undefined;
+
+    await calculateTaxes.default(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    const data: ResponseTaxPayload = res._getData();
+
+    expect(data.lines[0].total_gross_amount).toBe("28.00");
+    expect(data.lines[0].total_net_amount).toBe("28.00");
+    expect(data.lines[0].tax_rate).toBe("0");
+
+    expect(data.lines[1].total_gross_amount).toBe("28.00");
+    expect(data.lines[1].total_net_amount).toBe("28.00");
+    expect(data.lines[1].tax_rate).toBe("0");
+
     expect(res.statusCode).toBe(200);
 
     mockJose.mockRestore();

--- a/__tests__/pages/webhooks/order-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/order-calculate-taxes.test.ts
@@ -5,7 +5,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import * as taxJarRequest from "taxjar/dist/util/request";
 import { Request } from "taxjar/dist/util/types";
 import { ResponseTaxPayload } from "../../../backend/types";
-import * as calculateTaxes from "../../../pages/api/webhooks/order-calculate-taxes";
+import toNextHandler from "../../../pages/api/webhooks/order-calculate-taxes";
 import { setupPollyMiddleware, setupRecording } from "../../pollySetup";
 import {
   dummyFetchTaxesResponse,
@@ -48,7 +48,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     const orderPayload = { ...dummyOrderPayload };
     req.body = [orderPayload];
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -77,7 +77,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     const orderPayload = { ...dummyOrderPayload };
     req.body = [orderPayload];
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -108,7 +108,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -146,7 +146,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -168,11 +168,9 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = { ...dummyOrderPayload };
@@ -186,7 +184,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -216,11 +214,9 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = { ...dummyOrderPayload };
@@ -237,7 +233,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -268,11 +264,9 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = { ...dummyOrderPayload };
@@ -294,7 +288,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -325,11 +319,9 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = { ...dummyOrderPayload };
@@ -352,7 +344,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -384,11 +376,9 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = { ...dummyOrderPayload };
@@ -411,7 +401,7 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await calculateTaxes.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );

--- a/__tests__/pages/webhooks/order-created.test.ts
+++ b/__tests__/pages/webhooks/order-created.test.ts
@@ -5,7 +5,7 @@ import * as joseModule from "jose";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as taxJarRequest from "taxjar/dist/util/request";
 import { Request } from "taxjar/dist/util/types";
-import * as orderCreated from "../../../pages/api/webhooks/order-created";
+import toNextHandler from "../../../pages/api/webhooks/order-created";
 import { setupPollyMiddleware, setupRecording } from "../../pollySetup";
 import {
   dummyOrderCreatedPayload,
@@ -47,7 +47,7 @@ describe("api/webhooks/order-created", () => {
     const orderPayload = dummyOrderCreatedPayload;
     req.body = orderPayload;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -76,7 +76,7 @@ describe("api/webhooks/order-created", () => {
     const orderPayload = dummyOrderCreatedPayload;
     req.body = orderPayload;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -107,7 +107,7 @@ describe("api/webhooks/order-created", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -145,7 +145,7 @@ describe("api/webhooks/order-created", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -167,11 +167,9 @@ describe("api/webhooks/order-created", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = dummyOrderCreatedPayload;
@@ -185,7 +183,7 @@ describe("api/webhooks/order-created", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );
@@ -213,11 +211,9 @@ describe("api/webhooks/order-created", () => {
 
     const mockJose = jest
       .spyOn(joseModule, "flattenedVerify")
-      .mockReturnValue(
-        Promise.resolve(
-          {} as unknown as joseModule.FlattenedVerifyResult &
-            joseModule.ResolvedKey
-        )
+      .mockResolvedValue(
+        {} as unknown as joseModule.FlattenedVerifyResult &
+          joseModule.ResolvedKey
       );
 
     const orderPayload = dummyOrderCreatedPayload;
@@ -233,7 +229,7 @@ describe("api/webhooks/order-created", () => {
     // the processed body doesn't exist.
     req.body = undefined;
 
-    await orderCreated.default(
+    await toNextHandler(
       req as unknown as NextApiRequest,
       res as unknown as NextApiResponse
     );

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/all lines with charge taxes set to false",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:45:45 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:45:45.226Z",
+        "time": 262,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 262
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
@@ -1,0 +1,220 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/with discounts and line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:38:03 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.621Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "2c11f8d6fc2cf43786f6b9045bab7502",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 313,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "TaxJar/Node (Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64; x64; node 16.15.0; OpenSSL/1.1.1n+quic) taxjar-node/4.0.1"
+            },
+            {
+              "name": "host",
+              "value": "api.sandbox.taxjar.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 313
+            }
+          ],
+          "headersSize": 403,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"from_country\":\"PL\",\"from_zip\":\"53-601\",\"from_state\":\"\",\"from_city\":\"WROCŁAW\",\"from_street\":\"Teczowa 71\",\"to_country\":\"GB\",\"to_zip\":\"BH15 1AB\",\"to_state\":\"\",\"to_city\":\"POOLE\",\"to_street\":\"8559 Lakes Avenue \",\"shipping\":10,\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"quantity\":1,\"unit_price\":28,\"discount\":1.5}]}"
+          },
+          "queryString": [],
+          "url": "https://api.sandbox.taxjar.com/v2/taxes"
+        },
+        "response": {
+          "bodySize": 753,
+          "content": {
+            "mimeType": "application/json",
+            "size": 753,
+            "text": "{\"tax\":{\"order_total_amount\":36.5,\"shipping\":10.0,\"taxable_amount\":36.5,\"amount_to_collect\":8.4,\"rate\":0.23,\"has_nexus\":true,\"freight_taxable\":true,\"tax_source\":\"origin\",\"jurisdictions\":{\"country\":\"PL\",\"city\":\"WROCŁAW\"},\"breakdown\":{\"taxable_amount\":36.5,\"tax_collectable\":8.4,\"combined_tax_rate\":0.23,\"country_taxable_amount\":36.5,\"country_tax_rate\":0.23,\"country_tax_collectable\":8.4,\"shipping\":{\"taxable_amount\":10.0,\"tax_collectable\":2.3,\"combined_tax_rate\":0.23,\"country_taxable_amount\":10.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":2.3},\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"taxable_amount\":26.5,\"tax_collectable\":6.1,\"combined_tax_rate\":0.23,\"country_taxable_amount\":26.5,\"country_tax_rate\":0.23,\"country_tax_collectable\":6.1}]}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"456f885d2165bb4bcf818a1438d7b6b1\""
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "x-request-id",
+              "value": "98d4892e-e369-4533-8a5e-ddb500bde5ec"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.013715"
+            },
+            {
+              "name": "content-length",
+              "value": "753"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.815Z",
+        "time": 397,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 397
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/checkout-calculate-taxes_3218862916/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
@@ -1,0 +1,220 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/checkout-calculate-taxes/with line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:38:03 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:02.844Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      },
+      {
+        "_id": "0918ccb9706697cf85bc912e27597597",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 311,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "TaxJar/Node (Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64; x64; node 16.15.0; OpenSSL/1.1.1n+quic) taxjar-node/4.0.1"
+            },
+            {
+              "name": "host",
+              "value": "api.sandbox.taxjar.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 311
+            }
+          ],
+          "headersSize": 403,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"from_country\":\"PL\",\"from_zip\":\"53-601\",\"from_state\":\"\",\"from_city\":\"WROCŁAW\",\"from_street\":\"Teczowa 71\",\"to_country\":\"GB\",\"to_zip\":\"BH15 1AB\",\"to_state\":\"\",\"to_city\":\"POOLE\",\"to_street\":\"8559 Lakes Avenue \",\"shipping\":10,\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"quantity\":1,\"unit_price\":28,\"discount\":0}]}"
+          },
+          "queryString": [],
+          "url": "https://api.sandbox.taxjar.com/v2/taxes"
+        },
+        "response": {
+          "bodySize": 758,
+          "content": {
+            "mimeType": "application/json",
+            "size": 758,
+            "text": "{\"tax\":{\"order_total_amount\":38.0,\"shipping\":10.0,\"taxable_amount\":38.0,\"amount_to_collect\":8.74,\"rate\":0.23,\"has_nexus\":true,\"freight_taxable\":true,\"tax_source\":\"origin\",\"jurisdictions\":{\"country\":\"PL\",\"city\":\"WROCŁAW\"},\"breakdown\":{\"taxable_amount\":38.0,\"tax_collectable\":8.74,\"combined_tax_rate\":0.23,\"country_taxable_amount\":38.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":8.74,\"shipping\":{\"taxable_amount\":10.0,\"tax_collectable\":2.3,\"combined_tax_rate\":0.23,\"country_taxable_amount\":10.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":2.3},\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"taxable_amount\":28.0,\"tax_collectable\":6.44,\"combined_tax_rate\":0.23,\"country_taxable_amount\":28.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":6.44}]}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"c58a7e5db33320062c1045bde04819cc\""
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "x-request-id",
+              "value": "5dec4463-634b-4adf-b80b-3d88f220d2ed"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.013192"
+            },
+            {
+              "name": "content-length",
+              "value": "758"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.030Z",
+        "time": 578,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 578
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/all-lines-with-charge-taxes-set-to-false_1242416524/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/all lines with charge taxes set to false",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:46:47 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:46:47.658Z",
+        "time": 222,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 222
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-discounts-and-line-that-should-not-have-calculated-taxes_1077603000/recording.har
@@ -1,0 +1,220 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/with discounts and line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:38:03 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.621Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "2c11f8d6fc2cf43786f6b9045bab7502",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 313,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "TaxJar/Node (Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64; x64; node 16.15.0; OpenSSL/1.1.1n+quic) taxjar-node/4.0.1"
+            },
+            {
+              "name": "host",
+              "value": "api.sandbox.taxjar.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 313
+            }
+          ],
+          "headersSize": 403,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"from_country\":\"PL\",\"from_zip\":\"53-601\",\"from_state\":\"\",\"from_city\":\"WROCŁAW\",\"from_street\":\"Teczowa 71\",\"to_country\":\"GB\",\"to_zip\":\"BH15 1AB\",\"to_state\":\"\",\"to_city\":\"POOLE\",\"to_street\":\"8559 Lakes Avenue \",\"shipping\":10,\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"quantity\":1,\"unit_price\":28,\"discount\":1.5}]}"
+          },
+          "queryString": [],
+          "url": "https://api.sandbox.taxjar.com/v2/taxes"
+        },
+        "response": {
+          "bodySize": 753,
+          "content": {
+            "mimeType": "application/json",
+            "size": 753,
+            "text": "{\"tax\":{\"order_total_amount\":36.5,\"shipping\":10.0,\"taxable_amount\":36.5,\"amount_to_collect\":8.4,\"rate\":0.23,\"has_nexus\":true,\"freight_taxable\":true,\"tax_source\":\"origin\",\"jurisdictions\":{\"country\":\"PL\",\"city\":\"WROCŁAW\"},\"breakdown\":{\"taxable_amount\":36.5,\"tax_collectable\":8.4,\"combined_tax_rate\":0.23,\"country_taxable_amount\":36.5,\"country_tax_rate\":0.23,\"country_tax_collectable\":8.4,\"shipping\":{\"taxable_amount\":10.0,\"tax_collectable\":2.3,\"combined_tax_rate\":0.23,\"country_taxable_amount\":10.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":2.3},\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"taxable_amount\":26.5,\"tax_collectable\":6.1,\"combined_tax_rate\":0.23,\"country_taxable_amount\":26.5,\"country_tax_rate\":0.23,\"country_tax_collectable\":6.1}]}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"456f885d2165bb4bcf818a1438d7b6b1\""
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "x-request-id",
+              "value": "6e9d520b-7551-46ac-ab93-aa8bd42061df"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.013114"
+            },
+            {
+              "name": "content-length",
+              "value": "753"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.816Z",
+        "time": 400,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 400
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
+++ b/__tests__/recordings/api_946514567/webhooks_2823233743/order-calculate-taxes_3082751374/with-line-that-should-not-have-calculated-taxes_2581615363/recording.har
@@ -1,0 +1,220 @@
+{
+  "log": {
+    "_recordingName": "api/webhooks/order-calculate-taxes/with line that should not have calculated taxes",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "219bcc23608f59163a2c86b4bcfb0949",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 207,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "207"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 308,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"query FetchAppMetafields($keys: [String!]) {\\n  app {\\n    id\\n    privateMetafields(keys: $keys)\\n    __typename\\n  }\\n}\",\"operationName\":\"FetchAppMetafields\",\"variables\":{\"keys\":[\"channel-pln\"]}}"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 653,
+          "content": {
+            "mimeType": "application/json",
+            "size": 653,
+            "text": "{\"data\":{\"app\":{\"id\":\"QXBwOjE=\",\"privateMetafields\":{\"channel-pln\":\"{\\\"shipFromCountry\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"PL\\\"},\\\"shipFromZip\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"53-601\\\"},\\\"shipFromCity\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"WROCŁAW\\\"},\\\"shipFromStreet\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"Teczowa 71\\\"},\\\"shipFromState\\\":{\\\"encrypted\\\":false,\\\"value\\\":\\\"\\\"},\\\"apiKey\\\":{\\\"encrypted\\\":true,\\\"value\\\":\\\"U2FsdGVkX1+vwewxrCWG98Hnr8Qx/MXEZfUmS6IQEIM=\\\"},\\\"active\\\":{\\\"encrypted\\\":false,\\\"value\\\":true},\\\"sandbox\\\":{\\\"encrypted\\\":false,\\\"value\\\":true}}\"},\"__typename\":\"App\"}},\"extensions\":{\"cost\":{\"requestedQueryCost\":1,\"maximumAvailable\":50000}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 04 Aug 2022 10:38:03 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.9.6"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "716"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:02.829Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "0918ccb9706697cf85bc912e27597597",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 311,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "TaxJar/Node (Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64; x64; node 16.15.0; OpenSSL/1.1.1n+quic) taxjar-node/4.0.1"
+            },
+            {
+              "name": "host",
+              "value": "api.sandbox.taxjar.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 311
+            }
+          ],
+          "headersSize": 403,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"from_country\":\"PL\",\"from_zip\":\"53-601\",\"from_state\":\"\",\"from_city\":\"WROCŁAW\",\"from_street\":\"Teczowa 71\",\"to_country\":\"GB\",\"to_zip\":\"BH15 1AB\",\"to_state\":\"\",\"to_city\":\"POOLE\",\"to_street\":\"8559 Lakes Avenue \",\"shipping\":10,\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"quantity\":1,\"unit_price\":28,\"discount\":0}]}"
+          },
+          "queryString": [],
+          "url": "https://api.sandbox.taxjar.com/v2/taxes"
+        },
+        "response": {
+          "bodySize": 758,
+          "content": {
+            "mimeType": "application/json",
+            "size": 758,
+            "text": "{\"tax\":{\"order_total_amount\":38.0,\"shipping\":10.0,\"taxable_amount\":38.0,\"amount_to_collect\":8.74,\"rate\":0.23,\"has_nexus\":true,\"freight_taxable\":true,\"tax_source\":\"origin\",\"jurisdictions\":{\"country\":\"PL\",\"city\":\"WROCŁAW\"},\"breakdown\":{\"taxable_amount\":38.0,\"tax_collectable\":8.74,\"combined_tax_rate\":0.23,\"country_taxable_amount\":38.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":8.74,\"shipping\":{\"taxable_amount\":10.0,\"tax_collectable\":2.3,\"combined_tax_rate\":0.23,\"country_taxable_amount\":10.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":2.3},\"line_items\":[{\"id\":\"Q2hlY2tvdXRMaW5lOjU=\",\"taxable_amount\":28.0,\"tax_collectable\":6.44,\"combined_tax_rate\":0.23,\"country_taxable_amount\":28.0,\"country_tax_rate\":0.23,\"country_tax_collectable\":6.44}]}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"c58a7e5db33320062c1045bde04819cc\""
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "x-request-id",
+              "value": "f696317b-a91c-4477-995c-5109558f2619"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.015585"
+            },
+            {
+              "name": "content-length",
+              "value": "758"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-08-04T10:38:03.024Z",
+        "time": 584,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 584
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/backend/taxHandlers.ts
+++ b/backend/taxHandlers.ts
@@ -74,12 +74,12 @@ const calculateTaxes = async (
     ...taxData,
     lines: linesWithChargeTaxes,
   };
-  const taxResposne =
+  const taxResponse =
     linesWithChargeTaxes.length !== 0
       ? await fetchTaxes(taxDataWithChargeTaxes, taxJarConfig)
       : undefined;
 
-  const taxDetails = taxResposne?.tax.breakdown;
+  const taxDetails = taxResponse?.tax.breakdown;
   const shippingDetails = taxDetails?.shipping;
 
   const shippingPriceGross = shippingDetails

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -80,7 +80,7 @@ export type FetchTaxesLinePayload = {
   chargeTaxes: boolean;
   unitAmount: number;
   totalAmount: number;
-}
+};
 export type FetchTaxesPayload = {
   channel: ChannelPayload;
   address: AddressPayload;


### PR DESCRIPTION
Saleor sends us information on what lines should have included charge taxes. This PR introduces a logic that skips the lines when charge taxes is set to false