### PR TITLE
Fix tax rate value format returned to Saleor

### DIFF
--- a/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/checkout-calculate-taxes.test.ts
@@ -205,11 +205,11 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     const data: ResponseTaxPayload = res._getData();
     expect(data.shipping_price_gross_amount).toBe("12.30");
     expect(data.shipping_price_net_amount).toBe("10.00");
-    expect(data.shipping_tax_rate).toBe("0.23");
+    expect(data.shipping_tax_rate).toBe("23.00");
     expect(data.lines.length).toBe(1);
     expect(data.lines[0].total_gross_amount).toBe("34.44");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
     expect(res.statusCode).toBe(200);
 
     mockJose.mockRestore();
@@ -269,11 +269,11 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // amounts already include propagated discount
     expect(data.lines[0].total_gross_amount).toBe("32.60");
     expect(data.lines[0].total_net_amount).toBe("26.50");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("32.60");
     expect(data.lines[1].total_net_amount).toBe("26.50");
-    expect(data.lines[1].tax_rate).toBe("0.23");
+    expect(data.lines[1].tax_rate).toBe("23.00");
     expect(res.statusCode).toBe(200);
 
     mockJose.mockRestore();
@@ -330,11 +330,11 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     expect(data.lines[0].total_gross_amount).toBe("34.44");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("28.00");
     expect(data.lines[1].total_net_amount).toBe("28.00");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 
@@ -396,11 +396,11 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
     // amounts already include propagated discount
     expect(data.lines[0].total_gross_amount).toBe("32.60");
     expect(data.lines[0].total_net_amount).toBe("26.50");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("26.50");
     expect(data.lines[1].total_net_amount).toBe("26.50");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 
@@ -460,11 +460,11 @@ describe("api/webhooks/checkout-calculate-taxes", () => {
 
     expect(data.lines[0].total_gross_amount).toBe("28.00");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0");
+    expect(data.lines[0].tax_rate).toBe("0.00");
 
     expect(data.lines[1].total_gross_amount).toBe("28.00");
     expect(data.lines[1].total_net_amount).toBe("28.00");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 

--- a/__tests__/pages/webhooks/order-calculate-taxes.test.ts
+++ b/__tests__/pages/webhooks/order-calculate-taxes.test.ts
@@ -205,11 +205,11 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     expect(data.shipping_price_gross_amount).toBe("12.30");
     expect(data.shipping_price_net_amount).toBe("10.00");
-    expect(data.shipping_tax_rate).toBe("0.23");
+    expect(data.shipping_tax_rate).toBe("23.00");
     expect(data.lines.length).toBe(1);
     expect(data.lines[0].total_gross_amount).toBe("34.44");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
     expect(res.statusCode).toBe(200);
 
     mockJose.mockRestore();
@@ -268,11 +268,11 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // amounts already include propagated discount
     expect(data.lines[0].total_gross_amount).toBe("32.60");
     expect(data.lines[0].total_net_amount).toBe("26.50");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("32.60");
     expect(data.lines[1].total_net_amount).toBe("26.50");
-    expect(data.lines[1].tax_rate).toBe("0.23");
+    expect(data.lines[1].tax_rate).toBe("23.00");
     expect(res.statusCode).toBe(200);
 
     mockJose.mockRestore();
@@ -328,11 +328,11 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     expect(data.lines[0].total_gross_amount).toBe("34.44");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("28.00");
     expect(data.lines[1].total_net_amount).toBe("28.00");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 
@@ -393,11 +393,11 @@ describe("api/webhooks/order-calculate-taxes", () => {
     // amounts already include propagated discount
     expect(data.lines[0].total_gross_amount).toBe("32.60");
     expect(data.lines[0].total_net_amount).toBe("26.50");
-    expect(data.lines[0].tax_rate).toBe("0.23");
+    expect(data.lines[0].tax_rate).toBe("23.00");
 
     expect(data.lines[1].total_gross_amount).toBe("26.50");
     expect(data.lines[1].total_net_amount).toBe("26.50");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 
@@ -454,11 +454,11 @@ describe("api/webhooks/order-calculate-taxes", () => {
 
     expect(data.lines[0].total_gross_amount).toBe("28.00");
     expect(data.lines[0].total_net_amount).toBe("28.00");
-    expect(data.lines[0].tax_rate).toBe("0");
+    expect(data.lines[0].tax_rate).toBe("0.00");
 
     expect(data.lines[1].total_gross_amount).toBe("28.00");
     expect(data.lines[1].total_net_amount).toBe("28.00");
-    expect(data.lines[1].tax_rate).toBe("0");
+    expect(data.lines[1].tax_rate).toBe("0.00");
 
     expect(res.statusCode).toBe(200);
 

--- a/backend/taxHandlers.ts
+++ b/backend/taxHandlers.ts
@@ -108,10 +108,11 @@ export const calculateTaxes = async (
     data: {
       shipping_price_gross_amount: shippingPriceGross.toFixed(2),
       shipping_price_net_amount: shippingPriceNet.toFixed(2),
-      shipping_tax_rate: String(shippingTaxRate),
+      shipping_tax_rate: (shippingTaxRate * 100).toFixed(2),
       // lines order needs to be the same as for recieved payload.
       // lines that have chargeTaxes === false will have returned default value
       lines: linesWithDiscounts.map((line) => {
+        // FIXME: make sure that we use correct ID here
         const lineTax = taxDetails?.line_items?.find((l) => l.id === line.id);
         const totalGrossAmount = lineTax
           ? lineTax.taxable_amount + lineTax.tax_collectable
@@ -119,7 +120,9 @@ export const calculateTaxes = async (
         const totalNetAmount = lineTax
           ? lineTax.taxable_amount
           : line.totalAmount - line.discount;
-        const taxRate = lineTax ? String(lineTax.combined_tax_rate || 0) : "0";
+        const taxRate = lineTax
+          ? ((lineTax.combined_tax_rate || 0) * 100).toFixed(2)
+          : "0.00";
         return {
           total_gross_amount: totalGrossAmount.toFixed(2),
           total_net_amount: totalNetAmount.toFixed(2),


### PR DESCRIPTION
Instead of returing 0.23, we should return 23. https://docs.saleor.io/docs/3.x/developer/extending/apps/synchronous-webhooks/tax-webhooks#fields-1